### PR TITLE
Remove Azure.Storage.Blobs nuget dependency

### DIFF
--- a/src/MassTransit.Opinionated/MassTransit.Opinionated.csproj
+++ b/src/MassTransit.Opinionated/MassTransit.Opinionated.csproj
@@ -7,7 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Storage.Blobs" Version="12.14.1" />
         <PackageReference Include="MassTransit" Version="8.0.8" />
         <PackageReference Include="MassTransit.Azure.ServiceBus.Core" Version="8.0.8" />
         <PackageReference Include="MassTransit.Azure.Storage" Version="8.0.8" />


### PR DESCRIPTION
This dependency is bundled in MassTransit.Azure.Storage which is already referenced.